### PR TITLE
site.update accepts domainAliases attribute

### DIFF
--- a/lib/site.js
+++ b/lib/site.js
@@ -117,7 +117,8 @@ var attributesForUpdate = function(attributes) {
         notificationEmail: "notification_email",
         password: "password",
         github: "github",
-        repo: "repo"
+        repo: "repo",
+        domainAliases: "domain_aliases"
       },
       result = {};
 


### PR DESCRIPTION
At the beginning I though there is a bug with updating domain aliases on Netlify API side but it's just NodeJS library.