### PR TITLE
Update graceful-fs to 4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "base64-js": ">=0.0.4",
     "glob": ">=3.2.6",
-    "graceful-fs": "^3.0.4",
+    "graceful-fs": "^4.1.2",
     "semaphore": "^1.0.5",
     "when": "^3.7.5"
   },


### PR DESCRIPTION
Keeping graceful-fs in Node 7+ is broken since it alters fs. Leading to issues such as https://github.com/nodejs/node/issues/9377